### PR TITLE
Support for VoiceOver on Mac OS X

### DIFF
--- a/src/build_mac.sh
+++ b/src/build_mac.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+clang -dynamiclib -o reaper_osara.dylib -current_version 1.0 -compatibility_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -stdlib=libc++ -std=c++11 -I ../include -I ../include/WDL -I ../include/WDL/wdl/swell reaper_osara.cpp

--- a/src/build_mac.sh
+++ b/src/build_mac.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-clang -dynamiclib -o reaper_osara.dylib -current_version 1.0 -compatibility_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -stdlib=libc++ -std=c++11 -I ../include -I ../include/WDL -I ../include/WDL/wdl/swell reaper_osara.cpp
+clang++ -dynamiclib -o reaper_osara.dylib -current_version 1.0 -compatibility_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -stdlib=libc++ -I ../include -I ../include/WDL -I ../include/WDL/wdl/swell reaper_osara.cpp -fobjc-arc -framework Appkit osxa11y.mm

--- a/src/build_mac.sh
+++ b/src/build_mac.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-clang++ -dynamiclib -o reaper_osara.dylib -current_version 1.0 -compatibility_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -stdlib=libc++ -I ../include -I ../include/WDL -I ../include/WDL/wdl/swell reaper_osara.cpp -fobjc-arc -framework Appkit osxa11y.mm
+clang++ -dynamiclib -o reaper_osara.dylib -current_version 1.0 -compatibility_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -stdlib=libc++ -std=c++11 -I ../include -I ../include/WDL -I ../include/WDL/wdl/swell reaper_osara.cpp -fobjc-arc -framework Appkit osxa11y.mm

--- a/src/osxa11y.mm
+++ b/src/osxa11y.mm
@@ -1,0 +1,40 @@
+#import <AppKit/AppKit.h>
+#include "osxa11y_wrapper.h"
+
+@interface OSXA11y : NSObject
+- (void)announce:(NSString*)message;
+@end
+
+@implementation OSXA11y
+namespace NSA11yWrapper {
+  struct osxa11yImpl
+  {
+    OSXA11y* pWrapper;
+  };
+
+  void init()
+  {
+    impl = new osxa11yImpl;
+    impl->pWrapper = [[OSXA11y alloc] init];
+  }
+
+  void osxa11y_announce(const std::string& message)
+  {
+    NSString* param = [NSString stringWithUTF8String:message.c_str()];
+    [impl->pWrapper announce:param];
+  }
+
+  void destroy()
+  {
+    if (impl != NULL)
+      delete impl;
+  }    
+}
+
+- (void)announce:(NSString*)message {
+  NSDictionary *announcementInfo = @{NSAccessibilityAnnouncementKey : message,
+				     NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh)};
+
+  NSAccessibilityPostNotificationWithUserInfo([NSApp mainWindow], NSAccessibilityAnnouncementRequestedNotification, announcementInfo);
+}
+@end

--- a/src/osxa11y_wrapper.h
+++ b/src/osxa11y_wrapper.h
@@ -1,0 +1,14 @@
+#ifndef osxa11y_wrapper_h
+#define osxa11y_wrapper_h
+#include <iostream>
+
+namespace NSA11yWrapper {
+  struct osxa11yImpl;
+  static osxa11yImpl* impl;
+
+  void init();
+  void osxa11y_announce(const std::string& param);
+  void destroy();
+}
+ 
+#endif

--- a/src/reaper_osara.cpp
+++ b/src/reaper_osara.cpp
@@ -23,6 +23,7 @@
 // We only need this on Windows and it apparently causes compilation issues on Mac.
 #include <codecvt>
 #endif
+#include "osxa11y_wrapper.h" // NSA11y wrapper for OS X accessibility API
 #define REAPERAPI_MINIMAL
 #define REAPERAPI_IMPLEMENT
 #define REAPERAPI_WANT_GetLastTouchedTrack
@@ -136,6 +137,7 @@ void outputMessage(const string& message) {
 #else // _WIN32
 
 void outputMessage(const string& message) {
+  NSA11yWrapper::osxa11y_announce(message);
 }
 
 #endif // _WIN32
@@ -1347,6 +1349,7 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		guiThread = GetWindowThreadProcessId(mainHwnd, NULL);
 		winEventHook = SetWinEventHook(EVENT_OBJECT_FOCUS, EVENT_OBJECT_FOCUS, hInstance, handleWinEvent, 0, guiThread, WINEVENT_INCONTEXT);
 #endif
+		NSA11yWrapper::init(); // initialize NSA11y wrapper for OS X accessibility API
 
 		for (int i = 0; POST_COMMANDS[i].cmd; ++i)
 			postCommandsMap.insert(make_pair(POST_COMMANDS[i].cmd, POST_COMMANDS[i].execute));
@@ -1388,6 +1391,7 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
 		UnhookWinEvent(winEventHook);
 		accPropServices->Release();
 #endif
+		NSA11yWrapper::destroy(); // release NSA11y Wrapper
 		return 0;
 	}
 }


### PR DESCRIPTION
Adds a wrapper for NS accessibility API to enable posting notifications to AT. With this commit it is now possible to use OSARA on Mac OS X with VoiceOver.